### PR TITLE
Fix subcategory search params

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ Client.prototype.search = function(callback, search, category, subcategory)
 {
 	var category_tmp = category ? category : 'all';
 	var subcategory_tmp = subcategory ? subcategory : 'all';
-	this.get('search', 'category=' + category_tmp + '&subcategory=' + subcategory_tmp + '&do=search&name=' + encodeURIComponent(search), callback);
+	this.get('search', 'category=' + category_tmp + '&sub_category=' + subcategory_tmp + '&do=search&name=' + encodeURIComponent(search), callback);
 }
 
 Client.prototype.get_top_day = function(callback)


### PR DESCRIPTION
Ygg has changed it search URL, you should use sub_category instead of subcategory.

Example : https://www2.yggtorrent.gg/engine/search?name=&description=&file=&uploader=&category=2141&sub_category=2157&do=search